### PR TITLE
Adds support for dynamically calling public functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build*
 *.so
 *.pyc
 *.amx
+venv/

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -21,3 +21,6 @@ class TestLoad(unittest.TestCase):
         self.assertEqual(1, amx.exec('main'))
         self.assertEqual(2, amx.exec('foo', 10, 8))
         self.assertEqual(-2, amx.exec('foo', 8, 10))
+        self.assertEqual(1, amx.main())
+        self.assertEqual(2, amx.foo(10, 8))
+        self.assertEqual(-2, amx.foo(8, 10))


### PR DESCRIPTION
AMX now reads all public functions  available in script and stores them into  dict(name->index)

So it can easy now allow dynamic public functions calls like amx.foo(1, 2)